### PR TITLE
Adding support for PHP 8.0 Attributes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ before_install:
     - export PATH=$PATH:$PWD/geckodriver
     - if [[ $COVERAGE != true ]]; then phpenv config-rm xdebug.ini || true; fi
     - if ! [ -z "$STABILITY" ]; then composer config minimum-stability ${STABILITY}; fi;
+    - composer global config --no-interaction --no-plugins allow-plugins.symfony/flex true
     - composer global require symfony/flex --prefer-dist --no-interaction
     - composer require --with-all-dependencies ${DEPENDENCIES} --prefer-dist --no-interaction
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -6,10 +6,9 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
- * @brief The configuration class for the bundle, fairly straightforward
+ * The configuration class for the bundle, fairly straightforward
  *
- * The hCaptcha site key and secret are inside a 'hcaptcha' key in case we
- * need more configuration unrelated to hCaptcha later.
+ * The hCaptcha site key and secret are inside a 'hcaptcha' key in case we need more configuration unrelated to hCaptcha later.
  */
 class Configuration implements ConfigurationInterface
 {

--- a/DependencyInjection/MeteoConceptHCaptchaExtension.php
+++ b/DependencyInjection/MeteoConceptHCaptchaExtension.php
@@ -8,7 +8,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
 /**
- * @brief The bundle extension class, used to load the configuration
+ * The bundle extension class, used to load the configuration
  */
 class MeteoConceptHCaptchaExtension extends Extension
 {

--- a/Exception/BadAnswerFromHCaptchaException.php
+++ b/Exception/BadAnswerFromHCaptchaException.php
@@ -3,9 +3,8 @@
 namespace MeteoConcept\HCaptchaBundle\Exception;
 
 /**
- * @brief An exception representing a bad answer from the hCaptcha API
- * (either no response, or HTTP code !== 200, or response body not looking
- * like the specification, etc.)
+ * An exception representing a bad answer from the hCaptcha API
+ * (either no response, or HTTP code !== 200, or response body not looking like the specification, etc.)
  */
 class BadAnswerFromHCaptchaException extends \RuntimeException
 {

--- a/Form/DataTransformer/HCaptchaValueFetcher.php
+++ b/Form/DataTransformer/HCaptchaValueFetcher.php
@@ -8,8 +8,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use MeteoConcept\HCaptchaBundle\Form\HCaptchaResponse;
 
 /**
- * @brief A weird data transformer that actually does not act on the
- * field value but on a specific POST variables in the request
+ * A weird data transformer that actually does not act on the field value but on a specific POST variables in the request
  */
 class HCaptchaValueFetcher implements DataTransformerInterface
 {
@@ -26,8 +25,7 @@ class HCaptchaValueFetcher implements DataTransformerInterface
     protected $siteKey;
 
     /**
-     * @brief Constructs an instance of the HCaptchaValueFetcher from
-     * injected dependencies
+     * Constructs an instance of the HCaptchaValueFetcher from injected dependencies
      *
      * This class does nothing useful when displaying the form, it's
      * only useful on a POST request, when the form is submitted.
@@ -41,8 +39,7 @@ class HCaptchaValueFetcher implements DataTransformerInterface
     }
 
     /**
-     * @brief Set the hCaptcha site key configured for the form to which this
-     * data transformer is attached
+     * Set the hCaptcha site key configured for the form to which this data transformer is attached
      *
      * This site key is then embedded into the value of the hCaptcha form widget
      * in order to be sent to hCaptcha as pert of the verification request.

--- a/Form/HCaptchaResponse.php
+++ b/Form/HCaptchaResponse.php
@@ -3,10 +3,9 @@
 namespace MeteoConcept\HCaptchaBundle\Form;
 
 /**
- * @brief Stores the values put in the POST request by hCaptcha
+ * Stores the values put in the POST request by hCaptcha
  *
- * This class is mostly there for type safety. It's used both by the
- * HCaptchaFormType and the IsValidCaptcha constraint.
+ * This class is mostly there for type safety. It's used both by the HCaptchaFormType and the IsValidCaptcha constraint.
  */
 final class HCaptchaResponse
 {
@@ -29,8 +28,7 @@ final class HCaptchaResponse
     private $siteKey;
 
     /**
-     * @brief Constructs an immutable instance of HCaptchaResponse from a
-     * hCaptcha response and a user's IP address
+     * Constructs an immutable instance of HCaptchaResponse from a hCaptcha response and a user's IP address
      *
      * @param $response string The user's response to the CAPTCHA
      * challenge
@@ -44,7 +42,7 @@ final class HCaptchaResponse
     }
 
     /**
-     * @brief Gets the CAPTCHA challenge response
+     * Gets the CAPTCHA challenge response
      *
      * @return string The CAPTCHA challenge response set at the construction of
      * the instance
@@ -55,7 +53,7 @@ final class HCaptchaResponse
     }
 
     /**
-     * @brief Gets the user's IP address
+     * Gets the user's IP address
      *
      * @return string|null The user's IP address set at the construction of the
      * instance
@@ -66,7 +64,7 @@ final class HCaptchaResponse
     }
 
     /**
-     * @brief Gets the hCaptcha site key
+     * Gets the hCaptcha site key
      *
      * @return string|null The hCaptcha site key configured for the form, to be
      * sent back in the hCaptcha verification request

--- a/Form/HCaptchaType.php
+++ b/Form/HCaptchaType.php
@@ -16,13 +16,12 @@ use MeteoConcept\HCaptchaBundle\Form\DataTransformer\HCaptchaValueFetcher;
 use MeteoConcept\HCaptchaBundle\Validator\Constraints\IsValidCaptcha;
 
 /**
- * @brief A form type that represents a hCaptcha field/widget that the user
- * must solve before submitting the form
+ * A form type that represents a hCaptcha field/widget that the user must solve before submitting the form
  */
 class HCaptchaType extends AbstractType
 {
     /**
-     * @var HCaptchValueFetcher The data transformer used to get the CAPTCHA
+     * @var HCaptchaValueFetcher The data transformer used to get the CAPTCHA
      * response
      */
     private $valueFetcher;
@@ -33,7 +32,7 @@ class HCaptchaType extends AbstractType
     private $hcaptchaSiteKey;
 
     /**
-     * @brief Constructs the form type from injected dependencies
+     * Constructs the form type from injected dependencies
      *
      * @param HCaptchaValueFetcher $hcaptchaValueFetcher An instance of the
      * HCaptchaValueFetcher service

--- a/MeteoConceptHCaptchaBundle.php
+++ b/MeteoConceptHCaptchaBundle.php
@@ -5,7 +5,7 @@ namespace MeteoConcept\HCaptchaBundle;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
- * @brief This class makes the project a Symfony bundle
+ * This class makes the project a Symfony bundle
  */
 class MeteoConceptHCaptchaBundle extends Bundle
 {

--- a/Service/HCaptchaVerifier.php
+++ b/Service/HCaptchaVerifier.php
@@ -49,7 +49,7 @@ class HCaptchaVerifier
     const HCAPTCHA_VERIFY_URL = 'https://hcaptcha.com/siteverify';
 
     /**
-     * @brief Constructs the validator from injected dependencies
+     * Constructs the validator from injected dependencies
      *
      * @param ClientInterface $client The PSR-18 HTTP client service to make the
      * API call to hCaptcha

--- a/Validator/Constraints/IsValidCaptcha.php
+++ b/Validator/Constraints/IsValidCaptcha.php
@@ -7,7 +7,9 @@ use Symfony\Component\Validator\Constraint;
 /**
  * @brief Screams when the user has failed to solve the CAPTCHA
  * @Annotation
+ * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class IsValidCaptcha extends Constraint
 {
     /**

--- a/Validator/Constraints/IsValidCaptcha.php
+++ b/Validator/Constraints/IsValidCaptcha.php
@@ -5,7 +5,7 @@ namespace MeteoConcept\HCaptchaBundle\Validator\Constraints;
 use Symfony\Component\Validator\Constraint;
 
 /**
- * @brief Screams when the user has failed to solve the CAPTCHA
+ * Screams when the user has failed to solve the CAPTCHA
  * @Annotation
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  */

--- a/Validator/Constraints/IsValidCaptchaValidator.php
+++ b/Validator/Constraints/IsValidCaptchaValidator.php
@@ -12,7 +12,7 @@ use MeteoConcept\HCaptchaBundle\Form\HCaptchaResponse;
 use MeteoConcept\HCaptchaBundle\Service\HCaptchaVerifier;
 
 /**
- * @brief Validates a CAPTCHA using the hCaptcha API
+ * Validates a CAPTCHA using the hCaptcha API
  *
  * The value that the validator works with must be an instance of
  * HCaptchaResponse, such as the one built by
@@ -45,7 +45,7 @@ class IsValidCaptchaValidator extends ConstraintValidator
     private $validation;
 
     /**
-     * @brief Constructs the validator from injected dependencies
+     * Constructs the validator from injected dependencies
      *
      * @param HCaptchaVerifier $verifier The service that sends the verification
      * request to the hCaptcha endpoint


### PR DESCRIPTION
Using the validator, we have found that it allows use as a Doctrine Annotation but not as a PHP 8 Attribute.

This change is backwards compatible with older versions of PHP as they interpret it as a comment.